### PR TITLE
Add fontSize and paddingBottom props

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ var styles = StyleSheet.create({
 * [disableFocus](#disableFocus)
 * [filter](#filter)
 * [filterEnabled](#filterEnabled)
+* [fontSizeTrack](#fontSizeTrack)
 * [fullscreen](#fullscreen)
 * [fullscreenAutorotate](#fullscreenautorotate)
 * [fullscreenOrientation](#fullscreenorientation)
@@ -307,6 +308,7 @@ var styles = StyleSheet.create({
 * [minLoadRetryCount](#minLoadRetryCount)
 * [mixWithOthers](#mixWithOthers)
 * [muted](#muted)
+* [paddingBottomTrack](#paddingBottomTrack)
 * [paused](#paused)
 * [pictureInPicture](#pictureinpicture)
 * [playInBackground](#playinbackground)
@@ -471,6 +473,13 @@ Enable video filter.
 
 Platforms: iOS
 
+#### fontSizeTrack
+Adjust the font size of the subtitles in Android.
+* **Default font size of the device** - The default value for this props
+* **Other values (int)** - Change the font size
+
+Platforms: Android ExoPlayer
+
 #### fullscreen
 Controls whether the player enters fullscreen on play.
 * **false (default)** - Don't display the video in fullscreen
@@ -571,6 +580,13 @@ Controls whether the audio is muted
 * **true** - Mute audio
 
 Platforms: all
+
+#### paddingBottomTrack
+Adjust the padding bottom of the subtitles in Android.
+* **0.1 (default)** - Give a padding bottom of 0.1
+* **Other values (float)** - Change the padding bottom
+
+Platforms: Android ExoPlayer
 
 #### paused
 Controls whether the media is paused

--- a/Video.js
+++ b/Video.js
@@ -476,6 +476,8 @@ Video.propTypes = {
   fullscreenAutorotate: PropTypes.bool,
   fullscreenOrientation: PropTypes.oneOf(['all', 'landscape', 'portrait']),
   progressUpdateInterval: PropTypes.number,
+  paddingBottomTrack: PropTypes.number,
+  fontSizeTrack: PropTypes.number,
   useTextureView: PropTypes.bool,
   hideShutterView: PropTypes.bool,
   onLoadStart: PropTypes.func,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ExoPlayerView.java
@@ -11,6 +11,7 @@ import android.view.TextureView;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
+import android.util.TypedValue;
 
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlaybackException;
@@ -84,6 +85,14 @@ public final class ExoPlayerView extends FrameLayout {
         layout.addView(subtitleLayout, 2, layoutParams);
 
         addViewInLayout(layout, 0, aspectRatioParams);
+    }
+
+    public void setFontSizeTrack(int fontSizeTrack) {
+        subtitleLayout.setFixedTextSize(TypedValue.COMPLEX_UNIT_SP, fontSizeTrack);
+    }
+
+    public void setPaddingBottomTrack(float paddingBottomTrack) {
+        subtitleLayout.setBottomPaddingFraction(paddingBottomTrack);
     }
 
     private void clearVideoView() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1394,4 +1394,22 @@ class ReactExoplayerView extends FrameLayout implements
             }
         }
     }
+
+    /**
+     * Handling font size prop
+     *
+     * @param fontSizeTrack  fontSizeTrack prop, integer to define the font size of the text track
+    */
+    public void setFontSizeTrack(int fontSizeTrack) {
+        exoPlayerView.setFontSizeTrack(fontSizeTrack);
+    }
+
+    /**
+     * Handling padding bottom track prop
+     *
+     * @param fontSizeTrack  paddingBottomTrack prop, float to define the padding bottom of the text track
+    */
+    public void setPaddingBottomTrack(float paddingBottomTrack) {
+        exoPlayerView.setPaddingBottomTrack(paddingBottomTrack);
+    }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -70,6 +70,8 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_SELECTED_VIDEO_TRACK_VALUE = "value";
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
+    private static final String PROP_FONT_SIZE_TRACK = "fontSizeTrack";
+    private static final String PROP_PADDING_BOTTOM_TRACK = "paddingBottomTrack";
 
     private ReactExoplayerConfig config;
 
@@ -312,6 +314,16 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_CONTROLS, defaultBoolean = false)
     public void setControls(final ReactExoplayerView videoView, final boolean controls) {
         videoView.setControls(controls);
+    }
+
+    @ReactProp(name = PROP_FONT_SIZE_TRACK)
+    public void setFontSizeTrack(final ReactExoplayerView videoView, final int fontSizeTrack) {
+        videoView.setFontSizeTrack(fontSizeTrack);
+    }
+
+    @ReactProp(name = PROP_PADDING_BOTTOM_TRACK, defaultFloat = 0.1f)
+    public void setPaddingBottomTrack(final ReactExoplayerView videoView, final float paddingBottomTrack) {
+        videoView.setPaddingBottomTrack(paddingBottomTrack);
     }
 
     @ReactProp(name = PROP_BUFFER_CONFIG)


### PR DESCRIPTION
Fix issue #1335

Font size
Before the font size of the subtitles was set by default for Android and the default size was really large and looks weird on some devices. It was not possible to set the font size via JavaScript or edit the VTT file. Now with these changes, it is possible to set a font size via JavaScript using the prop: fontSizeTrack

Padding bottom
It seems that on some devices the subtitles were hidden, so with the paddingBottonTrack prop, it is possible to define via JavaScript a padding-bottom to better position the subtitles on the screen.